### PR TITLE
Class dynamic properties are deprecated in > php8.2

### DIFF
--- a/src/Http/SalesforceRequest.php
+++ b/src/Http/SalesforceRequest.php
@@ -18,6 +18,7 @@ class SalesforceRequest {
   protected $baseUrl;
   protected $apiPrefix;
   protected $timeout;
+  protected $headers;
   protected $requestBody;
   protected $returnsStream;
   protected $sink;


### PR DESCRIPTION
On php 8.2 and more the following deprecation warning is triggered:

```
Deprecated function: Creation of dynamic property Salesforce\Http\SalesforceRequest::$headers is deprecated in Salesforce\Http\SalesforceRequest->__construct()
```