### PR TITLE
Allow passing in full url for query.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -44,4 +44,14 @@ class Client {
     );
   }
 
+  public function url($url) {
+    return new SalesforceRequest(
+      'GET',
+      $url,
+      $this->accessToken,
+      $this->baseUrl,
+      NULL
+    );
+  }
+
 }

--- a/src/Http/SalesforceRequest.php
+++ b/src/Http/SalesforceRequest.php
@@ -132,7 +132,7 @@ class SalesforceRequest {
    *   Request URL.
    */
   private function getRequestUrl() {
-    $url = $this->apiPrefix . '/' . $this->endpoint;
+    $url = implode('/', array_filter([$this->apiPrefix, $this->endpoint]));
 
     if (!empty($this->urlQuery)) {
       $url .= '?' . $this->urlQuery;


### PR DESCRIPTION
New method to allow query request by providing full URL.

Use case:
To be able to pass in next batch of results
https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_query_more_results.htm